### PR TITLE
Enable version number in custom commit message

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,14 +29,8 @@ const buildCurrent = helpers.getBuildNumberFromPlist(pathToPlist);
 const build = buildCurrent + 1;
 
 // getting commit message
-let message
-if(argv.m || argv.message) {
-  message = argv.m || argv.message
-  message = message.replace('${version}', version)
-} else {
-  message = `release ${version}: increase versions and build numbers`;
-}
-
+const messageTemplate = argv.m || argv.message || 'release ${version}: increase versions and build numbers';
+const message = messageTemplate.replace('${version}', version);
 
 log.info('\nI\'m going to increase the version in:');
 log.info(`- package.json (${pathToPackage});`, 1);

--- a/index.js
+++ b/index.js
@@ -29,7 +29,13 @@ const buildCurrent = helpers.getBuildNumberFromPlist(pathToPlist);
 const build = buildCurrent + 1;
 
 // getting commit message
-const message = argv.m || argv.message || `release ${version}: increase versions and build numbers`;
+let message
+if(argv.m || argv.message) {
+  message = argv.m || argv.message
+  message = message.replace('${version}', version)
+} else {
+  message = `release ${version}: increase versions and build numbers`;
+}
 
 
 log.info('\nI\'m going to increase the version in:');


### PR DESCRIPTION
This is a great little tool. I added the functionality to use `${version}` as a placeholder in the custom commit message that will be replaced by the actual version number. 
