### PR TITLE
Yarn doesn't need explicit `run` or `--`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,17 +84,17 @@ git commit -m 'version:up command added'
 
 **4. Increase version when needed**
 ```bash
-yarn run version:up -- --major
+yarn version:up --major
 ```
 
 Or via npm:
 ```bash
-npm run version:up -- --major
+npm version:up --major
 ```
 ## Options
-You can pass option name and value with following syntax (remember to put `--` before options):
+You can pass option name and value with following syntax (remember to put `--` before options if you are using npm, with yarn this is not needed):
 ```
-yarn run version:up -- --flag value
+yarn version:up --flag value
 ```
 
 | **Option** | **Type** | **Default value** | **Description** |

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ yarn version:up --major
 
 Or via npm:
 ```bash
-npm version:up --major
+npm run version:up -- --major
 ```
 ## Options
 You can pass option name and value with following syntax (remember to put `--` before options if you are using npm, with yarn this is not needed):


### PR DESCRIPTION
Yarn doesn't really need to say `run` or use the extra `--` to pass additional flags, that is just needed with standard npm. See https://yarnpkg.com/en/docs/cli/run